### PR TITLE
add GetMain to help people get main

### DIFF
--- a/bower/component.go
+++ b/bower/component.go
@@ -16,8 +16,20 @@ type Component struct {
 	Dependencies    map[string]string `json:"dependencies"`
 	DevDependencies map[string]string `json:"devDependencies"`
 	Private         bool              `json:"private,omitempty"`
+}
 
-	// TODO(sqs): add Main
+// Get the main of component
+func (c *Component) GetMain() []string {
+	res := make([]string, 0)
+	switch ms := c.Main.(type) {
+	case string:
+		res = append(res, ms)
+	case []interface{}:
+		for _, m := range ms {
+			res = append(res, m.(string))
+		}
+	}
+	return res
 }
 
 // ParseBowerJSON parses a bower.json file from data.


### PR DESCRIPTION
Because sometimes main is string and sometimes it is []string, just can use interface{} as main's type, it is little confuse, so add a GetMain function to help people use